### PR TITLE
Added conservativeCollapse:true to html-minifier options to prevent...

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -17,6 +17,7 @@ Plugin.registerSourceHandler('ng.jade', {
     '$templateCache.put(\'' + newPath + '\', \'' +
       minify(contents.replace(/'/g, "\\'"), {
         collapseWhitespace : true,
+        conservativeCollapse : true,
         removeComments : true,
         minifyJS : true,
         minifyCSS: true,


### PR DESCRIPTION
... problems with HTML layout.

Without `conservativeCollapse : true`, forms with labels and inputs render touching each other, which is not desired. Please see below.

The HTML below works as expected when rendered in the browser, with one space between the label and the input.

```html
      <div class="form-group">
        <label for="nameInput">Name</label>
        <input ng-model="newParty.name" id="nameInput" type="text" class="form-control">
      </div>
```

This JADE fragment renders with labels touching the inputs, touching the label, etc.

```jade
      .form-group
        label(for="nameInput") Name
        input#nameInput.form-control(type="text", ng-model="newParty.name")
```

Adding `conservativeCollapse : true` to `html-minifier` options fixes this problem.