### PR TITLE
Fixed bug with "\n" in result file breaking <pre> elements.

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,7 +11,7 @@ Package.registerBuildPlugin({
     'plugin.js'
   ],
   npmDependencies : {
-    'html-minifier': '0.6.9',
-    'jade': '1.7.0'
+    'html-minifier': '0.7.2',
+    'jade': '1.9.2'
   }
 });

--- a/plugin.js
+++ b/plugin.js
@@ -3,7 +3,7 @@ var jade = Npm.require('jade');
 var jadeOpts = {pretty:true, compileDebug:false};
 
 Plugin.registerSourceHandler('ng.jade', {
-  isTemplate: true, 
+  isTemplate: true,
   archMatching: 'web'
 }, function(compileStep) {
   var contents = compileStep.read().toString('utf8');
@@ -27,7 +27,7 @@ Plugin.registerSourceHandler('ng.jade', {
 
   compileStep.addJavaScript({
     path : newPath,
-    data : results,
+    data : results.replace(/\n/g, '\\n'),
     sourcePath : compileStep.inputPath
   });
 });


### PR DESCRIPTION
A template, such as the one below, would result in the the meteor build process stopping with an error:

```jade
pre some text here
   | more text
   | even more text
```

A template, like this
```jade
pre some text
```
would work just fine. So I thought, perhaps new lines...

I traced the problem to new lines in the `results` variable. This apparently only happens with pre elements. I imagine, because they are supposed to preserve new lines.

Also, I updated package.js to require the latest npm versions of jade and html-minifier.
