### PR TITLE
Allow jade imports

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -7,6 +7,7 @@ Plugin.registerSourceHandler('ng.jade', {
   archMatching: 'web'
 }, function(compileStep) {
   var contents = compileStep.read().toString('utf8');
+  jadeOpts.filename = compileStep.inputPath;
   contents = jade.compile(contents, jadeOpts)();
 
   var newPath = compileStep.inputPath;


### PR DESCRIPTION
Hi,

Currently there is no way to use relative file imports with jade.
By defining jadeOpts.filename we can do `include .helper.jade`