### PR TITLE
include work with plugins

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -7,7 +7,7 @@ Plugin.registerSourceHandler('ng.jade', {
   archMatching: 'web'
 }, function(compileStep) {
   var contents = compileStep.read().toString('utf8');
-  jadeOpts.filename = compileStep.inputPath;
+  jadeOpts.filename = compileStep.fullInputPath;
   contents = jade.compile(contents, jadeOpts)();
 
   var newPath = compileStep.inputPath;


### PR DESCRIPTION
i dont know if the problem is with meteor 1.2 or with packages 
but 
jadeOpts.filename = compileStep.inputPath;
didn't work